### PR TITLE
upgrade log4js for compatibility with node 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "node": "0.6.x"
     },
     "dependencies": {
-        "log4js": "0.4.x",
+        "log4js": "0.6.x",
         "printf": "0.0.x",
         "optimist": "0.3.x"
     },


### PR DESCRIPTION
Something to do with the node-waf and node-gyp build systems
changing (don't know the details since this is my first
time looking at node).

Fixes #3
