### PR TITLE
Added patch to handle VR type with 'US or SS' as SS

### DIFF
--- a/src/vrs.coffee
+++ b/src/vrs.coffee
@@ -947,6 +947,9 @@ for_name = (name, ctx, buffer, values) ->
   if name == 'OB or OW'
     log.debug({vr: 'OW'}, "for_name: using OW for 'OB or OW'") if log.debug()
     name = 'OW'
+  if name == 'US or SS'
+    log.debug({vr: 'SS'}, "for_name: using SS for 'US or SS'") if log.debug()
+    name = 'SS'
   constr_fn = _VR_DICT[name]
   if not constr_fn?
     throw new DicomError("Unknown VR: #{name}")


### PR DESCRIPTION
... similar to how 'OB or OW' is treated as OW. I am not sure if defaulting to SS is better than US, however. This at least allows me to load other DICOM headers without crashing (https://github.com/grmble/node-dicom/issues/6) 